### PR TITLE
Add first example reference model test (Regions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,19 +88,15 @@ jobs:
       # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
       # the references in lcov.info
       # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/7
-      # - name: Run unit tests
-      #   run: |
-      #     npm run test:lcov
-      #     sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' lcov.info
-
       - name: Run unit tests
         run: |
           npm run pretest
           npm run test:lcov
+          sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' lcov.info
 
-      # - name: Analyze with SonarCloud
-      #   if: github.actor != 'dependabot[bot]'
-      #   uses: sonarsource/sonarcloud-github-action@master
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets
+      - name: Analyze with SonarCloud
+        if: github.actor != 'dependabot[bot]'
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       POSTGRES_PORT: 5432
       POSTGRES_DB: wabs_node_test
       POSTGRES_DB_TEST: wabs_node_test
+      DEFAULT_USER_PASSWORD: P@55word
       ENVIRONMENT: dev
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,8 @@ jobs:
 
       - name: Run unit tests
         run: |
-          npm run test
+          npm run pretest
+          npm run test:lcov
 
       # - name: Analyze with SonarCloud
       #   if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,14 +88,18 @@ jobs:
       # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
       # the references in lcov.info
       # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/7
+      # - name: Run unit tests
+      #   run: |
+      #     npm run test:lcov
+      #     sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' lcov.info
+
       - name: Run unit tests
         run: |
-          npm run test:lcov
-          sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' lcov.info
+          npm run test
 
-      - name: Analyze with SonarCloud
-        if: github.actor != 'dependabot[bot]'
-        uses: sonarsource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets
+      # - name: Analyze with SonarCloud
+      #   if: github.actor != 'dependabot[bot]'
+      #   uses: sonarsource/sonarcloud-github-action@master
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/specs/models/region.model.test.js
+++ b/specs/models/region.model.test.js
@@ -1,0 +1,117 @@
+// Test framework dependencies
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+
+// Test helpers
+import * as BillRunHelper from '../support/helpers/bill-run.helper.js'
+import BillRunModel from '../../app/models/bill-run.model.js'
+import * as LicenceHelper from '../support/helpers/licence.helper.js'
+import LicenceModel from '../../app/models/licence.model.js'
+import * as RegionHelper from '../support/helpers/region.helper.js'
+import { closeConnection } from '../support/database.js'
+
+// Thing under test
+import RegionModel from '../../app/models/region.model.js'
+
+describe('Region model', () => {
+  let testBillRuns
+  let testLicences
+  let testRecord
+
+  before(async () => {
+    testRecord = RegionHelper.select()
+
+    testBillRuns = []
+    testLicences = []
+    for (let i = 0; i < 2; i++) {
+      const billRun = await BillRunHelper.add({ regionId: testRecord.id })
+
+      testBillRuns.push(billRun)
+
+      const licence = await LicenceHelper.add({ regionId: testRecord.id })
+
+      testLicences.push(licence)
+    }
+  })
+
+  after(async () => {
+    await closeConnection()
+  })
+
+  describe('Basic query', async () => {
+    it('can successfully run a basic query', async () => {
+      const result = await RegionModel.query().findById(testRecord.id)
+
+      assert(result instanceof RegionModel)
+      assert.equal(result.id, testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to bill runs', () => {
+      it('can successfully run a related query', async () => {
+        const query = await RegionModel.query()
+          .innerJoinRelated('billRuns')
+
+        assert(query)
+      })
+
+      it('can eager load the bill runs', async () => {
+        const result = await RegionModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('billRuns')
+
+        assert(result instanceof RegionModel)
+        assert.equal(result.id, testRecord.id)
+
+        assert(result.billRuns instanceof Array)
+        assert(result.billRuns[0] instanceof BillRunModel)
+
+        const includesFirstBillRun = result.billRuns.some((billRun) => {
+          return billRun.id === testBillRuns[0].id
+        })
+
+        assert(includesFirstBillRun)
+
+        const includesSecondBillRun = result.billRuns.some((billRun) => {
+          return billRun.id === testBillRuns[1].id
+        })
+
+        assert(includesSecondBillRun)
+      })
+    })
+
+    describe('when linking to licences', () => {
+      it('can successfully run a related query', async () => {
+        const query = await RegionModel.query()
+          .innerJoinRelated('licences')
+
+        assert(query)
+      })
+
+      it('can eager load the licences', async () => {
+        const result = await RegionModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licences')
+
+        assert(result instanceof RegionModel)
+        assert.equal(result.id, testRecord.id)
+
+        assert(result.licences instanceof Array)
+        assert(result.licences[0] instanceof LicenceModel)
+
+        const includesFirstLicence = result.licences.some((licence) => {
+          return licence.id === testLicences[0].id
+        })
+
+        assert(includesFirstLicence)
+
+        const includesSecondLicence = result.licences.some((licence) => {
+          return licence.id === testLicences[1].id
+        })
+
+        assert(includesSecondLicence)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Now that we've imported and updated all our models, it is time to start adding some example tests to further research node-test as an alternative to Lab.

In database terms, all models are accessed and used via Objection.js. However, for testing, we split them into two camps: reference models and transaction models.

Reference models are things we don't expect to create within the service as part of daily use. They are records that would be seeded, such as regions.

Transaction models are things we expect to be created, such as bill runs or licences.

When it comes to testing we seed the tables that back the reference models, hence their helpers generally have a `select()` method. Transaction models, when needed, will be created during the testing. Their helpers generally have an `add()` method.

When we first tried this test, node-test wouldn't quit. It wouldn't even move to the next spec after `region.model.test.js`. This is a problem we first faced when pulling this project together. Time away has clearly helped because we were able to diagnose the cause as the database connection we create blocks node test from exiting (see [test_runner: allow to force exit after all tests finished](https://github.com/nodejs/node/issues/49925) for a deeper dive into the issue which gave us our a-ha! moment).

This does mean we'll need to add an `after()` block to any spec that results in a DB connection being made, but that should be simple enough.

Completing this example has also highlighted that we'll probably want to extend `assert` in some way, to avoid 'messy duplication' in our tests.

But for now, here is our first working model node-test!