### PR TITLE
Add 1st example transaction model test (Workflow)

### DIFF
--- a/specs/models/workflow.model.test.js
+++ b/specs/models/workflow.model.test.js
@@ -1,0 +1,59 @@
+// Test framework dependencies
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+
+// Test helpers
+import { closeConnection } from '../support/database.js'
+import * as LicenceHelper from '../support/helpers/licence.helper.js'
+import LicenceModel from '../../app/models/licence.model.js'
+import * as WorkflowHelper from '../support/helpers/workflow.helper.js'
+
+// Thing under test
+import WorkflowModel from '../../app/models/workflow.model.js'
+
+describe('Workflow model', () => {
+  let testLicence
+  let testRecord
+
+  before(async () => {
+    testLicence = await LicenceHelper.add()
+
+    testRecord = await WorkflowHelper.add({ licenceId: testLicence.id })
+  })
+
+  after(async () => {
+    await closeConnection()
+  })
+
+  describe('Basic query', async () => {
+    it('can successfully run a basic query', async () => {
+      const result = await WorkflowModel.query().findById(testRecord.id)
+
+      assert(result instanceof WorkflowModel)
+      assert.equal(result.id, testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to licence', () => {
+      it('can successfully run a related query', async () => {
+        const query = await WorkflowModel.query()
+          .innerJoinRelated('licence')
+
+        assert(query)
+      })
+
+      it('can eager load the licence', async () => {
+        const result = await WorkflowModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('licence')
+
+        assert(result instanceof WorkflowModel)
+        assert.equal(result.id, testRecord.id)
+
+        assert(result.licence instanceof LicenceModel)
+        assert.deepEqual(result.licence, testLicence)
+      })
+    })
+  })
+})


### PR DESCRIPTION
In [Add first example reference model test (Regions)](https://github.com/DEFRA/water-abstraction-node-test/pull/14) we added our first model test and chose a 'reference' type.

In database terms, all models are accessed and used via Objection.js. However, for testing, we split them into two camps: reference models and transaction models.

Reference models are things we don't expect to create within the service as part of daily use. They are records that would be seeded, such as regions.

Transaction models are things we expect to be created, such as bill runs, licences or in this case, workflow.

This change migrates the model tests for `WorkflowModel`.