### PR TITLE
Add example of simple mocking

### DIFF
--- a/app/services/bill-runs/check-busy-bill-runs.service.js
+++ b/app/services/bill-runs/check-busy-bill-runs.service.js
@@ -1,0 +1,41 @@
+/**
+ * Check if any bill runs are being processed or cancelled
+ * @module CheckBusyBillRunsService
+ */
+
+import { db } from '../../../db/db.js'
+
+/**
+ * Check if any bill runs are busy building or cancelling
+ *
+ * A bill run is 'cancelling' if its status is `cancel`. A bill run is 'building' if its status is `processing`,
+ * `queued`, or `sending`.
+ *
+ * @returns {Promise<string>} the state of busy bill runs; 'cancelling', 'building', 'both', or 'none'
+ */
+export default async function go () {
+  const { building, cancelling } = await _fetch()
+
+  if (building && cancelling) {
+    return 'both'
+  }
+
+  if (building) {
+    return 'building'
+  }
+
+  if (cancelling) {
+    return 'cancelling'
+  }
+
+  return 'none'
+}
+
+async function _fetch () {
+  const results = await db.select(
+    db.raw("EXISTS(SELECT 1 FROM public.bill_runs bb WHERE bb.status = 'cancel') AS cancelling"),
+    db.raw("EXISTS(SELECT 1 FROM public.bill_runs bb WHERE bb.status IN ('processing', 'queued', 'sending')) AS building")
+  )
+
+  return results[0]
+}

--- a/specs/services/bill-runs/check-busy-bill-runs.service.test.js
+++ b/specs/services/bill-runs/check-busy-bill-runs.service.test.js
@@ -1,0 +1,71 @@
+// Test framework dependencies
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+
+// Things we need to stub
+import { db } from '../../../db/db.js'
+
+// Thing under test
+import CheckBusyBillRunsService from '../../../app/services/bill-runs/check-busy-bill-runs.service.js'
+
+describe('Check Busy Bill Runs service', () => {
+  afterEach(() => {
+    mock.reset()
+  })
+
+  describe('when there are both building and cancelling bill runs', () => {
+    beforeEach(() => {
+      mock.method(db, 'select', async () => {
+        return [{ cancelling: true, building: true }]
+      })
+    })
+
+    it('returns "both"', async () => {
+      const result = await CheckBusyBillRunsService()
+
+      assert.equal(result, 'both')
+    })
+  })
+
+  describe('when there are cancelling bill runs', () => {
+    beforeEach(() => {
+      mock.method(db, 'select', async () => {
+        return [{ cancelling: true, building: false }]
+      })
+    })
+
+    it('returns "cancelling"', async () => {
+      const result = await CheckBusyBillRunsService()
+
+      assert.equal(result, 'cancelling')
+    })
+  })
+
+  describe('when there are building bill runs', () => {
+    beforeEach(() => {
+      mock.method(db, 'select', async () => {
+        return [{ cancelling: false, building: true }]
+      })
+    })
+
+    it('returns "building"', async () => {
+      const result = await CheckBusyBillRunsService()
+
+      assert.equal(result, 'building')
+    })
+  })
+
+  describe('when there are no building or cancelling bill runs', () => {
+    beforeEach(() => {
+      mock.method(db, 'select', async () => {
+        return [{ cancelling: false, building: false }]
+      })
+    })
+
+    it('returns "none"', async () => {
+      const result = await CheckBusyBillRunsService()
+
+      assert.equal(result, 'none')
+    })
+  })
+})


### PR DESCRIPTION
We've picked `CheckBusyBillRunsService`, a service in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system), as our first candidate to demonstrate mocking.

It relies on our `db/db.js` module to make a raw query to the DB. In **water-abstraction-system**, we're able to mock out the call to `select()` and, therefore, easily provide the data `CheckBusyBillRunsService` needs to exercise its logic.

We wanted to try and replicate this simple example in node-test runner, and we have!