### PR TITLE
Add first simple controller test example

### DIFF
--- a/specs/controllers/root.controller.test.js
+++ b/specs/controllers/root.controller.test.js
@@ -5,7 +5,7 @@ import assert from 'node:assert/strict'
 // For running our service
 import { init } from '../../app/server.js'
 
-describe('Check Busy Bill Runs service', () => {
+describe('Root controller: GET /', () => {
   let options
   let server
 

--- a/specs/controllers/root.controller.test.js
+++ b/specs/controllers/root.controller.test.js
@@ -1,0 +1,26 @@
+// Test framework dependencies
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+
+// For running our service
+import { init } from '../../app/server.js'
+
+describe('Check Busy Bill Runs service', () => {
+  let options
+  let server
+
+  // Create server before each test
+  beforeEach(async () => {
+    server = await init()
+
+    options = { method: 'GET', url: '/' }
+  })
+
+  it('displays the correct message', async () => {
+    const response = await server.inject(options)
+    const payload = JSON.parse(response.payload)
+
+    assert.equal(response.statusCode, 200)
+    assert.equal(payload.status, 'alive')
+  })
+})


### PR DESCRIPTION
Currently, we only have the one controller but adding a test allows us to confirm we can initialise an instance of the server in the same way we'd do it in our [Hapi Lab](https://hapi.dev/module/lab/) tests.