### PR TITLE
Update CI test script to use multiple reporters

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pretest": "NODE_ENV=test node db/clean.js",
     "test": "node --test --experimental-test-coverage",
     "test:skip": "node --test --experimental-test-coverage",
-    "test:lcov": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info specs"
+    "test:lcov": "node --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info specs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We thought we only had the option to set one reporter, and for CI, we need to code coverage in `lcov` format to support SonarCloud.

But we have since learned that we can specify multiple reporters. This change means that when we look at the job in CI, we can see the same output we get locally while still generating code coverage for SonarCloud.