### PR TITLE
Test against correct DB!

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "seed": "knex seed:run --knexfile knexfile.application.js",
     "lint": "eslint .",
     "pretest": "NODE_ENV=test node db/clean.js",
-    "test": "node --test --experimental-test-coverage",
-    "test:skip": "node --test --experimental-test-coverage",
-    "test:lcov": "node --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info specs"
+    "test": "NODE_ENV=test node --test --experimental-test-coverage",
+    "test:skip": "NODE_ENV=test node --test --experimental-test-coverage",
+    "test:lcov": "NODE_ENV=test node --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info specs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
By accident we realised our pretest was connecting to the correct DB and clean the test database. But when the tests were run they were connecting to the 'real' database! 😱

Set the correct NODE_ENV in the package.json run script fixes the issue.