### PR TITLE
Use Chai instead of node-assert for all assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ There's no 'right' way in development. But this feels a bit off to us. Hence our
 
 At this time **node-test** is looking to be a viable alternative to **Jest** and **Lab**. After migrating a file from **water-abstraction-system** to ESM, the test file we create here is very similar to what we would have done in **Lab**.
 
-All examples we've followed so far use the built-in [node:assert](https://nodejs.org/api/assert.html) module. It doesn't have the expressiveness of [Hapi code](https://hapi.dev/module/code/), but we've not hit any blockers so far.
+All examples we've followed so far use the built-in [node:assert](https://nodejs.org/api/assert.html) module. We didn't hit any blockers when first converting tests. But it doesn't have the expressiveness of [Hapi code](https://hapi.dev/module/code/), and it means every test needs updating.
+
+So, we brought in [chai](https://www.chaijs.com/api/), which **Hapi code** is built from. It works fine with **node-test**, doesn't appear to impact performance, and means in a lot of cases we can do a simple copy & paste of the current test.
 
 The output is similar to **Lab**, and we can see code coverage, though it is a little noisy (see comments below). We can also integrate the code coverage out put with SonarCloud.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@stylistic/eslint-plugin-js": "^1.8.1",
+        "chai": "^5.1.1",
         "eslint": "^8.57.0",
         "eslint-plugin-jsdoc": "^50.3.1",
         "pino-pretty": "^10.2.0",
@@ -981,6 +982,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -1124,6 +1135,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz",
+      "integrity": "sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1137,6 +1165,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/clone": {
@@ -1290,6 +1328,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -3542,6 +3590,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
+      "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -3867,6 +3922,16 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pg": {
       "version": "8.13.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@stylistic/eslint-plugin-js": "^1.8.1",
+    "chai": "^5.1.1",
     "eslint": "^8.57.0",
     "eslint-plugin-jsdoc": "^50.3.1",
     "pino-pretty": "^10.2.0",

--- a/specs/controllers/root.controller.test.js
+++ b/specs/controllers/root.controller.test.js
@@ -1,6 +1,6 @@
 // Test framework dependencies
 import { describe, it, beforeEach } from 'node:test'
-import assert from 'node:assert/strict'
+import { expect } from 'chai'
 
 // For running our service
 import { init } from '../../app/server.js'
@@ -20,7 +20,7 @@ describe('Root controller: GET /', () => {
     const response = await server.inject(options)
     const payload = JSON.parse(response.payload)
 
-    assert.equal(response.statusCode, 200)
-    assert.equal(payload.status, 'alive')
+    expect(response.statusCode).to.equal(200)
+    expect(payload.status).to.equal('alive')
   })
 })

--- a/specs/models/region.model.test.js
+++ b/specs/models/region.model.test.js
@@ -1,6 +1,6 @@
 // Test framework dependencies
 import { describe, it, before, after } from 'node:test'
-import assert from 'node:assert/strict'
+import { expect } from 'chai'
 
 // Test helpers
 import * as BillRunHelper from '../support/helpers/bill-run.helper.js'
@@ -42,8 +42,8 @@ describe('Region model', () => {
     it('can successfully run a basic query', async () => {
       const result = await RegionModel.query().findById(testRecord.id)
 
-      assert(result instanceof RegionModel)
-      assert.equal(result.id, testRecord.id)
+      expect(result).to.be.instanceOf(RegionModel)
+      expect(result.id).to.equal(testRecord.id)
     })
   })
 
@@ -53,7 +53,7 @@ describe('Region model', () => {
         const query = await RegionModel.query()
           .innerJoinRelated('billRuns')
 
-        assert(query)
+        expect(query).to.be.instanceOf(Array)
       })
 
       it('can eager load the bill runs', async () => {
@@ -61,23 +61,14 @@ describe('Region model', () => {
           .findById(testRecord.id)
           .withGraphFetched('billRuns')
 
-        assert(result instanceof RegionModel)
-        assert.equal(result.id, testRecord.id)
+        expect(result).to.be.instanceOf(RegionModel)
+        expect(result.id).to.equal(testRecord.id)
 
-        assert(result.billRuns instanceof Array)
-        assert(result.billRuns[0] instanceof BillRunModel)
+        expect(result.billRuns).to.be.instanceOf(Array)
+        expect(result.billRuns[0]).to.be.instanceOf(BillRunModel)
 
-        const includesFirstBillRun = result.billRuns.some((billRun) => {
-          return billRun.id === testBillRuns[0].id
-        })
-
-        assert(includesFirstBillRun)
-
-        const includesSecondBillRun = result.billRuns.some((billRun) => {
-          return billRun.id === testBillRuns[1].id
-        })
-
-        assert(includesSecondBillRun)
+        expect(result.billRuns).to.deep.include(testBillRuns[0])
+        expect(result.billRuns).to.deep.include(testBillRuns[1])
       })
     })
 
@@ -86,7 +77,7 @@ describe('Region model', () => {
         const query = await RegionModel.query()
           .innerJoinRelated('licences')
 
-        assert(query)
+        expect(query).to.be.instanceOf(Array)
       })
 
       it('can eager load the licences', async () => {
@@ -94,23 +85,13 @@ describe('Region model', () => {
           .findById(testRecord.id)
           .withGraphFetched('licences')
 
-        assert(result instanceof RegionModel)
-        assert.equal(result.id, testRecord.id)
+        expect(result).to.be.instanceOf(RegionModel)
+        expect(result.id).to.equal(testRecord.id)
 
-        assert(result.licences instanceof Array)
-        assert(result.licences[0] instanceof LicenceModel)
-
-        const includesFirstLicence = result.licences.some((licence) => {
-          return licence.id === testLicences[0].id
-        })
-
-        assert(includesFirstLicence)
-
-        const includesSecondLicence = result.licences.some((licence) => {
-          return licence.id === testLicences[1].id
-        })
-
-        assert(includesSecondLicence)
+        expect(result.licences).to.be.instanceOf(Array)
+        expect(result.licences[0]).to.be.instanceOf(LicenceModel)
+        expect(result.licences).to.deep.include(testLicences[0])
+        expect(result.licences).to.deep.include(testLicences[1])
       })
     })
   })

--- a/specs/models/workflow.model.test.js
+++ b/specs/models/workflow.model.test.js
@@ -1,6 +1,6 @@
 // Test framework dependencies
 import { describe, it, before, after } from 'node:test'
-import assert from 'node:assert/strict'
+import { expect } from 'chai'
 
 // Test helpers
 import { closeConnection } from '../support/database.js'
@@ -29,8 +29,8 @@ describe('Workflow model', () => {
     it('can successfully run a basic query', async () => {
       const result = await WorkflowModel.query().findById(testRecord.id)
 
-      assert(result instanceof WorkflowModel)
-      assert.equal(result.id, testRecord.id)
+      expect(result).to.be.instanceOf(WorkflowModel)
+      expect(result.id).to.equal(testRecord.id)
     })
   })
 
@@ -40,7 +40,7 @@ describe('Workflow model', () => {
         const query = await WorkflowModel.query()
           .innerJoinRelated('licence')
 
-        assert(query)
+        expect(query).to.be.instanceOf(Array)
       })
 
       it('can eager load the licence', async () => {
@@ -48,11 +48,11 @@ describe('Workflow model', () => {
           .findById(testRecord.id)
           .withGraphFetched('licence')
 
-        assert(result instanceof WorkflowModel)
-        assert.equal(result.id, testRecord.id)
+        expect(result).to.be.instanceOf(WorkflowModel)
+        expect(result.id).to.equal(testRecord.id)
 
-        assert(result.licence instanceof LicenceModel)
-        assert.deepEqual(result.licence, testLicence)
+        expect(result.licence).to.be.instanceOf(LicenceModel)
+        expect(result.licence).to.deep.equal(testLicence)
       })
     })
   })

--- a/specs/services/bill-runs/check-busy-bill-runs.service.test.js
+++ b/specs/services/bill-runs/check-busy-bill-runs.service.test.js
@@ -1,6 +1,6 @@
 // Test framework dependencies
 import { describe, it, beforeEach, afterEach, mock } from 'node:test'
-import assert from 'node:assert/strict'
+import { expect } from 'chai'
 
 // Things we need to stub
 import { db } from '../../../db/db.js'
@@ -23,7 +23,7 @@ describe('Check Busy Bill Runs service', () => {
     it('returns "both"', async () => {
       const result = await CheckBusyBillRunsService()
 
-      assert.equal(result, 'both')
+      expect(result).to.equal('both')
     })
   })
 
@@ -37,7 +37,7 @@ describe('Check Busy Bill Runs service', () => {
     it('returns "cancelling"', async () => {
       const result = await CheckBusyBillRunsService()
 
-      assert.equal(result, 'cancelling')
+      expect(result).to.equal('cancelling')
     })
   })
 
@@ -51,7 +51,7 @@ describe('Check Busy Bill Runs service', () => {
     it('returns "building"', async () => {
       const result = await CheckBusyBillRunsService()
 
-      assert.equal(result, 'building')
+      expect(result).to.equal('building')
     })
   })
 
@@ -65,7 +65,7 @@ describe('Check Busy Bill Runs service', () => {
     it('returns "none"', async () => {
       const result = await CheckBusyBillRunsService()
 
-      assert.equal(result, 'none')
+      expect(result).to.equal('none')
     })
   })
 })

--- a/specs/services/plugins/filter-routes.service.test.js
+++ b/specs/services/plugins/filter-routes.service.test.js
@@ -1,6 +1,6 @@
 // Test framework dependencies
 import { describe, it, beforeEach } from 'node:test'
-import assert from 'node:assert/strict'
+import { expect } from 'chai'
 
 // Thing under test
 import filterRoutesService from '../../../app/services/plugins/filter-routes.service.js'
@@ -16,7 +16,7 @@ describe('Filter routes service', () => {
     it('returns the routes unchanged', () => {
       const result = filterRoutesService(routes, 'dev')
 
-      assert.deepEqual(result, routes)
+      expect(result).to.deep.equal(routes)
     })
   })
 
@@ -28,14 +28,9 @@ describe('Filter routes service', () => {
     it('returns the routes filtered', () => {
       const result = filterRoutesService(routes, 'prd')
 
-      assert.notDeepEqual(result, routes)
-      assert.equal(result.length, 2)
-
-      const includesPathToBeFiltered = result.some((path) => {
-        return path.path === '/path-to-be-filtered'
-      })
-
-      assert.equal(includesPathToBeFiltered, false)
+      expect(result).not.to.deep.equal(routes)
+      expect(result).to.have.length(2)
+      expect(result).not.to.include('/path-to-be-filtered')
     })
   })
 })


### PR DESCRIPTION
All examples we've followed so far from documentation and blog posts have stuck to the node standard libraries. So, they used [node:assert](https://nodejs.org/api/assert.html), and we did too.

However, this means that we've had to update the assertions in every test we've migrated.

But like our existing tests, [Hapi lab](https://hapi.dev/module/lab/) is the framework (`describe()`, `it()`, `beforeEach()` etc), and [Hapi code](https://hapi.dev/module/code/) handles the assertions (`expect()`).

Our first examples, [node-test](https://nodejs.org/api/test.html) is the framework and [node:assert](https://nodejs.org/api/assert.html) handles the assertions. But could we mix it up? 🤔

Theoretically, we think we could have stuck with **Hapi code**. But we know it is just an opinionated rewrite of [chai](https://www.chaijs.com/api/). **chai** is much more familiar to Node developers and has much a stronger community supporting it. So, rather than **Hapi code**, could we use **chai** to handle assertions instead of **node:assert**?

Yes, we can!

The only difference we've hit so far (between **chai** and **Hapi code**) is that when comparing objects **Hapi code** uses `==` whereas **chai** uses `===`. We have to explicitly tell **chai** we are only interested in a [deep equality check](https://www.chaijs.com/api/bdd/#method_deep) (the properties are the same but they are not the same instance).

It does mean adding an extra dependency. One of the benefits of using **node-test** was that you don't need to rely on additional packages. But using **chai** makes transposing tests from [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) to ESM and **node-test** much more straightforward.