### PR TITLE
Maker test coverage more accurate

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "seed": "knex seed:run --knexfile knexfile.application.js",
     "lint": "eslint .",
     "pretest": "NODE_ENV=test node db/clean.js",
-    "test": "NODE_ENV=test node --experimental-test-coverage --test '**/*.test.js'",
-    "test:skip": "NODE_ENV=test node --experimental-test-coverage --test '**/*.test.js'",
-    "test:lcov": "NODE_ENV=test node --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info --test '**/*.test.js'"
+    "test": "NODE_ENV=test node --experimental-test-coverage --test-coverage-exclude 'test/**/*.js' --test-coverage-exclude 'db/migrations/**/*.js' --test-coverage-exclude 'db/seeds/**/*.js' --test '**/*.test.js'",
+    "test:skip": "NODE_ENV=test node --experimental-test-coverage --test-coverage-exclude 'test/**/*.js' --test-coverage-exclude 'db/migrations/**/*.js' --test-coverage-exclude 'db/seeds/**/*.js' --test '**/*.test.js'",
+    "test:lcov": "NODE_ENV=test node --experimental-test-coverage --test-coverage-exclude 'test/**/*.js' --test-coverage-exclude 'db/migrations/**/*.js' --test-coverage-exclude 'db/seeds/**/*.js' --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info --test '**/*.test.js'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
One of the reasons for pushing the service to use Node v22 is to take advantage of the additional support it has for the node test runner, one of which is the ability to configure what files code coverage should be reported for. Admittedly, it is still experimental, so how it works may change. But we foresee the functionality only improving and expanding.

This change updates the args we pass on the command line (again, hopefully, there'll be some way to move this to a shared config in the future!) to exclude those files on which we are not interested in reporting coverage.