### PR TITLE
Fix PM2 erroring when docker environment starts

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,7 +31,8 @@ export default [
       sourceType: 'module'
     },
     // Ignore the folder created when JSDocs are generated
-    ignores: ['docs/**/*'],
+    // Ignore pm2 config file (pm2 doesn't support ESM config files yet)
+    ignores: ['docs/**/*', 'pm2.config.cjs'],
     plugins: {
       // https://github.com/gajus/eslint-plugin-jsdoc
       jsdoc: jsdocPlugin

--- a/pm2.config.cjs
+++ b/pm2.config.cjs
@@ -1,3 +1,5 @@
+'use strict'
+
 const defaults = {
   autorestart: false,
   min_uptime: '3s',
@@ -28,7 +30,7 @@ const defaults = {
     'app/views',
     'app/public',
     'test',
-    '.eslintrc.cjs',
+    'eslint.config.js',
     'lcov.info',
     'Dockerfile',
     'docker-compose.yml',
@@ -41,7 +43,7 @@ const defaults = {
   ]
 }
 
-export default {
+module.exports = {
   apps: [
     {
       name: 'node-test',


### PR DESCRIPTION
When we added prettier and updated the ESLint config, we automatically updated the pm2 config file to ESM as well.

But there was a reason it still used CommonJS syntax and has a `.cjs` extension: PM2 can't handle the config file being written as ESM!

We did know this, we just forgot. This puts back the file (with the changes since then) and updates our ESLint config to stop shouting at us about it!